### PR TITLE
fix: guard import rows before processing

### DIFF
--- a/backend/src/routes/import.ts
+++ b/backend/src/routes/import.ts
@@ -157,6 +157,11 @@ async function importCompanies(rows: ExcelRow[], partnerId?: string): Promise<Im
   // First pass: collect and validate data
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
+    if (!row) {
+      errors++;
+      errorMessages.push(`Riga ${i + 1}: Dati azienda mancanti nel file`);
+      continue;
+    }
     try {
       const name = cleanData(row['Nome Azienda'] || row['Azienda'] || row['Nome']);
       const address = cleanData(row['Indirizzo'] || row['Address']);
@@ -336,6 +341,11 @@ async function importStudents(rows: ExcelRow[], partnerId?: string): Promise<Imp
   // First pass: collect and validate data
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
+    if (!row) {
+      errors++;
+      errorMessages.push(`Riga ${i + 1}: Dati studente mancanti nel file`);
+      continue;
+    }
     try {
       const name = cleanData(row['Nome Studente'] || row['Studente'] || row['Nome']);
       const email = cleanData(row['Email']);
@@ -512,6 +522,11 @@ async function importSupervisors(rows: ExcelRow[], partnerId?: string): Promise<
   // First pass: collect and validate data
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
+    if (!row) {
+      errors++;
+      errorMessages.push(`Riga ${i + 1}: Dati supervisore mancanti nel file`);
+      continue;
+    }
     try {
       const name = cleanData(row['Nome Supervisore'] || row['Supervisore'] || row['Nome']);
       const email = cleanData(row['Email']);


### PR DESCRIPTION
## Summary
- add explicit undefined-row guards while iterating imported Excel data for companies, students, and supervisors
- collect import error details when encountering missing row data to keep reporting consistent

## Testing
- npm run build *(fails: Cannot find module 'multer' or its corresponding type declarations.)*

------
https://chatgpt.com/codex/tasks/task_e_68d5589355b0832eb82e2794a35274d7